### PR TITLE
Google synchronize scheduler iis hosting issue resolved.

### DIFF
--- a/BlazorScheduler.csproj
+++ b/BlazorScheduler.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Calendar.v3" Version="1.49.0.2139" />
-    <PackageReference Include="Syncfusion.Blazor" Version="18.3.0.50" />
+    <PackageReference Include="Google.Apis.Calendar.v3" Version="1.68.0.3592" />
+    <PackageReference Include="Syncfusion.Blazor" Version="28.2.3" />
+	  <Content Include="token.json\**">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+	  </Content>
   </ItemGroup>
 
 </Project>

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -16,7 +16,7 @@
     protected async override Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        SelectedDate = new DateTime(2020, 11, 1);
+        SelectedDate = new DateTime(2025, 1, 30);
         DataSource = GoogleService.GetEvents(SelectedDate);
     }
 

--- a/Pages/_Host.cshtml
+++ b/Pages/_Host.cshtml
@@ -14,7 +14,8 @@
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="_content/Syncfusion.Blazor/styles/bootstrap4.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor/styles/bootstrap5.css" rel="stylesheet" />
+    <script src="_content/Syncfusion.Blazor/scripts/syncfusion-blazor.min.js" type="text/javascript"></script>
 </head>
 <body>
     <app>


### PR DESCRIPTION
**Issue : When hosting this sample in IIS, then scheduler not rendering properly.**

**Reason :** 
The issue occurs due to token.jon file was not moved while publishing. When publishing a Blazor application, the token.json file is not included by default because .json files are typically not marked for publishing.

Also, Theme changed to latest and dotnet version changed.